### PR TITLE
Add dark mode styles for newsoverview block

### DIFF
--- a/wp-content/themes/guide-os-theme/blocks/newsoverview/newsoverview.css
+++ b/wp-content/themes/guide-os-theme/blocks/newsoverview/newsoverview.css
@@ -90,6 +90,7 @@
         bottom: -80%;
         right: 50%;
         transform: translate(50%, -40%);
+        box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
         h2 {
             font-size: 1.5rem;
             margin: 0;
@@ -124,6 +125,13 @@
         }
         .content {
             transform: translate(50%, -50%) scale(1.05);
+        }
+    }
+    @media (prefers-color-scheme: dark) {
+        .content {
+            background-color: #121212;
+            color: #f6f6f6;
+            box-shadow: 0 0 10px rgba(255, 255, 255, 0.1);
         }
     }
 }


### PR DESCRIPTION
Introduced dark mode support by specifying background, text color, and box-shadow adjustments within a media query for `prefers-color-scheme: dark`. Also added a subtle box-shadow to improve UI consistency and aesthetics across themes.