### PR TITLE
Add VSCode configuration files for Xdebug support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+  "configurations": [
+    {
+      "name": "Listen for Xdebug",
+      "type": "php",
+      "request": "launch",
+      "hostname": "0.0.0.0",
+      "port": 9003,
+      "pathMappings": {
+        "/var/www/html": "${workspaceFolder}"
+      },
+      "preLaunchTask": "DDEV: Enable Xdebug",
+      "postDebugTask": "DDEV: Disable Xdebug",
+      "skipFiles": [
+        "**/vendor/**/*.php",
+        "**/wp-admin/**/*.php",
+        "**/wp-includes/**/*.php",
+        "**/wp-blog-header.php"
+      ]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "intelephense.environment.phpVersion": "8.3"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,23 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "DDEV: Enable Xdebug",
+			"type": "shell",
+			"command": "ddev xdebug on",
+			"presentation": {
+				"reveal": "silent",
+				"close": true
+			}
+		},
+		{
+			"label": "DDEV: Disable Xdebug",
+			"type": "shell",
+			"command": "ddev xdebug off",
+			"presentation": {
+				"reveal": "silent",
+				"close": true
+			}
+		}
+	]
+}


### PR DESCRIPTION
This pull request adds new VSCode configuration files to improve PHP development workflow, particularly with Xdebug and DDEV integration. The main changes include launch and task configurations for debugging and enabling/disabling Xdebug, as well as specifying the PHP version for the Intelephense extension.

VSCode Debugging and Task Automation:

* Added `.vscode/launch.json` with a configuration to listen for Xdebug connections on port 9003, including path mappings and integration with DDEV tasks to enable/disable Xdebug automatically.
* Added `.vscode/tasks.json` defining shell tasks to enable and disable Xdebug using DDEV commands, which are referenced in the launch configuration.

Editor Settings:

* Added `.vscode/settings.json` to specify PHP 8.3 as the target version for the Intelephense extension, ensuring compatibility and improved code intelligence.